### PR TITLE
Corrected bug with cloning date 

### DIFF
--- a/library/org/chof/zend/utilities/TimeUtils.php
+++ b/library/org/chof/zend/utilities/TimeUtils.php
@@ -75,7 +75,7 @@ class Chof_Util_TimeUtils
     
     if ($format == 'datetime')
     {
-      return $time;
+      return clone $time;
     }
     elseif ($format == 'number')
     {


### PR DESCRIPTION
datetime to datetime conversion in Chof_Util_TimeUtil::returntime() function caused the original date to be reused. Added a clone instruction to manage that going foreward